### PR TITLE
run cargo audit once per lockfile

### DIFF
--- a/fpr/pipelines/cargo_audit.py
+++ b/fpr/pipelines/cargo_audit.py
@@ -102,7 +102,7 @@ async def run_cargo_audit(org_repo, commit="master"):
                 ripgrep_version=ripgrep_version,
                 rustc_version=rustc_version,
                 cargo_audit_version=cargo_audit_version,
-                audit_output=await containers.cargo_audit(c, working_dir=working_dir),
+                audit_output=cargo_audit,
             )
             log.debug("{} audit result {}".format(name, result))
             log.debug("{} stdout: {}".format(name, await c.log(stdout=True)))


### PR DESCRIPTION
Duped with L92 https://github.com/mozilla-services/find-package-rugaru/compare/fix-cargo-audit-once?expand=1#diff-ffee6895e266afae70f1a7387b5e0dc8L92