### PR TITLE
Fix 119 gh meta rate limit

### DIFF
--- a/fpr/models/github.py
+++ b/fpr/models/github.py
@@ -307,10 +307,6 @@ class RequestResponseExchange:
 
 _ = quiz.SELECTOR
 
-# TODO: save E-Tag or Last-Modified then send If-Modified-Since or
-# If-None-Match and check for HTTP 304 Not Modified
-# https://developer.github.com/v3/#conditional-requests
-# NB: this might not be supported https://developer.github.com/v4/guides/resource-limitations/
 rate_limit_gql = _.rateLimit[
     # https://developer.github.com/v4/object/ratelimit/
     _.limit.cost.remaining.resetAt

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,6 +4,9 @@ python_version = 3.8
 [mypy-aiodocker]
 ignore_missing_imports = True
 
+[mypy-backoff]
+ignore_missing_imports = True
+
 [mypy-networkx]
 ignore_missing_imports = True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 -i https://pypi.org/simple
 aiodocker
 aiohttp
+backoff
 networkx
 pydot
 quiz

--- a/requirements.txt.lock
+++ b/requirements.txt.lock
@@ -13,6 +13,9 @@ async_timeout==3.0.1 \
 attrs==19.2.0 \
     --hash=sha256:ec20e7a4825331c1b5ebf261d111e16fa9612c1f7a5e1f884f12bd53a664dfd2 \
     --hash=sha256:f913492e1663d3c36f502e5e9ba6cd13cf19d7fab50aa13239e420fef95e1396
+backoff==1.10.0 \
+    --hash=sha256:5e73e2cbe780e1915a204799dba0a01896f45f4385e636bcca7a0614d879d0cd \
+    --hash=sha256:b8fba021fac74055ac05eb7c7bfce4723aedde6cd0a504e5326bcb0bdd6d19a4
 chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691


### PR DESCRIPTION
Fixes: #119

Might need some additional work to use the backoff values and sync rate limited state across workers (in a custom `wait_gen` that checks those things then delegates to `backoff.expo`), but we'll do that if necessary.  