### PR TITLE
Fix erroring on empty responses

### DIFF
--- a/fpr/pipelines/github_metadata.py
+++ b/fpr/pipelines/github_metadata.py
@@ -68,7 +68,9 @@ async def run_graphql(
     GitHub API and returns the response JSON
     """
     try:
-        return await executor(gql_query)
+        result = await executor(gql_query)
+        log.debug(f"{worker_name} run_graphql: got result: {result}")
+        return result
     except quiz.ErrorResponse as err:
         log.error(
             f"{worker_name} run_graphql: got a quiz.ErrorResponse {err} {err.errors}"

--- a/fpr/serialize_util.py
+++ b/fpr/serialize_util.py
@@ -7,11 +7,15 @@ def get_in(d: Dict, path: Iterable[Union[str, int]], default: Any = None):
         sentinel = object()
     for path_part in path:
         if isinstance(path_part, str):
+            if not hasattr(d, "get"):
+                return default
             assert hasattr(d, "get")
             d = d.get(path_part, sentinel)
             if d == sentinel:
                 return default
         elif isinstance(path_part, int):
+            if not hasattr(d, "__getitem__"):
+                return default
             assert hasattr(d, "__getitem__")
             if not (-1 < path_part < len(d)):
                 return default

--- a/tests/unit/test_serialize_util.py
+++ b/tests/unit/test_serialize_util.py
@@ -13,27 +13,27 @@ import context
 import fpr.serialize_util as m
 
 
+default_get_in_obj = {"a": 1, "b": {"foo": [-1, {}]}}
+
+
 @pytest.mark.parametrize(
-    "path,default,expected",
+    "value,path,default,expected",
     [
-        ([], None, {"a": 1, "b": {"foo": [-1, {}]}}),
-        ([-7], "not found", "not found"),
-        (["a"], None, 1),
-        (["b", "foo", 1], None, {}),
-        (["b", "foo", 1], None, {}),
+        (default_get_in_obj, [], None, {"a": 1, "b": {"foo": [-1, {}]}}),
+        (default_get_in_obj, [-7], "not found", "not found"),
+        (default_get_in_obj, ["a"], None, 1),
+        (default_get_in_obj, ["b", "foo", 1], None, {}),
+        (default_get_in_obj, ["b", "foo", 1], None, {}),
+        ("", [""], None, None),
+        (set(), [-1], None, None),
     ],
 )
-def test_get_in(path, default, expected):
-    assert m.get_in({"a": 1, "b": {"foo": [-1, {}]}}, path, default) == expected
+def test_get_in(value, path, default, expected):
+    assert m.get_in(value, path, default) == expected
 
 
 @pytest.mark.parametrize(
-    "value,path,default,expected_error",
-    [
-        ("", [""], None, AssertionError),
-        (set(), [-1], None, AssertionError),
-        ({}, [set()], None, NotImplementedError),
-    ],
+    "value,path,default,expected_error", [({}, [set()], None, NotImplementedError)]
 )
 def test_get_in_errors(value, path, default, expected_error):
     with pytest.raises(expected_error):


### PR DESCRIPTION
Changes:

* add raw responses to debug logs 
* `serialize_util.get_in` returns None for mismatched path part and value types

since we can get a valid JSON response with an empty repository e.g.

```json
{
  "repository": {}
}
```

which breaks `get_in` for log_str lookups and for pagination