### PR TITLE
models: add selection on GH meta repo default branch

### DIFF
--- a/fpr/models/github.py
+++ b/fpr/models/github.py
@@ -337,7 +337,18 @@ repo_gql = _.repository(owner=MISSING, name=MISSING)[
         _.key
     ]
     .primaryLanguage[_.name.id]
-    .defaultBranchRef[_.name.id.prefix.target]
+    .defaultBranchRef[
+        _
+        .name
+        .id
+        .prefix
+        .target[
+            _
+            .id
+            .oid
+            .commitUrl
+         ]
+    ]
 ]
 # fmt: on
 

--- a/tests/fixtures/graphql/REPO_first_selection.graphql
+++ b/tests/fixtures/graphql/REPO_first_selection.graphql
@@ -27,7 +27,11 @@
       name
       id
       prefix
-      target
+      target {
+        id
+        oid
+        commitUrl
+      }
     }
   }
 }


### PR DESCRIPTION
Fix the error:

"Field must have selections (field 'target' returns
GitObject but has no selections. Did you mean 'target { ... }'?)"