### PR TITLE
yarn support

### DIFF
--- a/fpr/docker/containers.py
+++ b/fpr/docker/containers.py
@@ -282,8 +282,8 @@ def temp_dockerfile_tgz(fileobject: BinaryIO) -> Generator[IO, None, None]:
 
 
 async def build(dockerfile: bytes, tag: str, pull: bool = False) -> str:
+    # NB: can shell out to docker build if this doesn't work
     async with aiodocker_client() as client:
-        log.info(f"building image {tag}")
         log.debug(f"building image {tag} with dockerfile:\n{dockerfile}")
         with temp_dockerfile_tgz(BytesIO(dockerfile)) as tar_obj:
             async for build_log_line in client.images.build(

--- a/fpr/models/docker_image.py
+++ b/fpr/models/docker_image.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class DockerImageName:
+    # e.g. mozilla/dependencyscan:latest
+    #      ^repo   ^name          ^tag
+
+    # repository name e.g. mozilla
+    # use docker.io/library for the official images
+    # should be official or an org you trust without a trailing slash
+    repo: Optional[str]
+
+    # image name e.g. dependencyscan
+    name: str
+
+    # tag name defaults to latest, stretch, 1.31, 1-slim
+    tag: str = "latest"
+
+    @property
+    def repo_name(self) -> str:
+        if self.repo is None:
+            return f"{self.name}"
+        else:
+            return f"{self.repo}/{self.name}"
+
+    @property
+    def repo_name_tag(self) -> str:
+        return f"{self.repo_name}:{self.tag}"
+
+
+@dataclass
+class DockerImage:
+    base: DockerImageName
+
+    # local tag
+    local: DockerImageName
+
+    # dockerfile contents template should start with 'FROM {base.repo_name}:{base.tag}'
+    dockerfile_template: str
+
+    @property
+    def dockerfile_bytes(self) -> bytes:
+        return self.dockerfile_template.format(base=self.base).encode("utf-8")

--- a/fpr/models/language.py
+++ b/fpr/models/language.py
@@ -224,7 +224,7 @@ package_managers: Dict[str, PackageManager] = {
         ),
     ]
 }
-
+package_manager_names = [pm.name for pm in package_managers.values()]
 
 languages: Dict[str, Language] = {
     l.name: l
@@ -244,3 +244,4 @@ languages: Dict[str, Language] = {
         ),
     ]
 }
+language_names = [l.name for l in languages.values()]

--- a/fpr/pipelines/postprocess.py
+++ b/fpr/pipelines/postprocess.py
@@ -19,6 +19,7 @@ from typing import (
     Generator,
     List,
     Optional,
+    Sequence,
     Tuple,
     Union,
 )
@@ -34,9 +35,14 @@ from fpr.serialize_util import (
     REPO_FIELDS,
 )
 from fpr.models import GitRef, OrgRepo, Pipeline, SerializedNodeJSMetadata
-from fpr.models.language import DependencyFile, languages, ContainerTask
+from fpr.models.language import (
+    DependencyFile,
+    languages,
+    ContainerTask,
+    package_managers,
+)
 from fpr.models.pipeline import add_infile_and_outfile
-from fpr.models.nodejs import flatten_deps
+from fpr.models.nodejs import NPMPackage, flatten_deps
 from fpr.pipelines.util import exc_to_str
 
 
@@ -69,7 +75,7 @@ def parse_args(pipeline_parser: argparse.ArgumentParser) -> argparse.ArgumentPar
 # want: (repo, ref/tag, dep_files w/ hashes, deps, [dep. stats or vuln. stats] (join for final analysis))
 
 
-def parse_stdout(stdout: Optional[str]) -> Optional[Dict]:
+def parse_stdout_as_json(stdout: Optional[str]) -> Optional[Dict]:
     if stdout is None:
         return None
 
@@ -82,6 +88,173 @@ def parse_stdout(stdout: Optional[str]) -> Optional[Dict]:
     return None
 
 
+def parse_stdout_as_jsonlines(stdout: Optional[str]) -> Optional[Sequence[Dict]]:
+    if stdout is None:
+        return None
+
+    try:
+        return list(
+            line
+            for line in iter_jsonlines(stdout.split("\n"))
+            if isinstance(line, dict)
+        )
+    except json.decoder.JSONDecodeError as e:
+        log.warn(f"error parsing stdout as JSON: {e}")
+
+    return None
+
+
+def parse_npm_list(parsed_stdout: Dict) -> Dict:
+    deps = [dep for dep in flatten_deps(parsed_stdout)]
+    updates = {"problems": get_in(parsed_stdout, ["problems"], [])}
+    updates["dependencies"] = [asdict(dep) for dep in deps]
+    updates["dependencies_count"] = len(deps)
+    updates["problems_count"] = len(updates["problems"])
+
+    updates["root"] = asdict(deps[-1]) if len(deps) else None
+    updates["direct_dependencies_count"] = (
+        len(deps[-1].dependencies) if len(deps) else None
+    )
+    updates["graph_stats"] = (
+        get_graph_stats(npm_packages_to_networkx_digraph(deps)) if deps else dict()
+    )
+    return updates
+
+
+def parse_yarn_list(parsed_stdout: Sequence[Dict]) -> Optional[Dict]:
+    updates: Dict = dict(dependencies=[])
+    deps: List[NPMPackage] = []
+    for line in parsed_stdout:
+        line_type, line_data = line.get("type", None), line.get("data", dict())
+        if line_type == "tree":
+            deps.extend(
+                NPMPackage.from_yarn_tree_line(dep) for dep in line_data["trees"]
+            )
+        else:
+            # TODO: populate "problems" to match npm list field?
+            log.warn(
+                f"got unexpected yarn list line type: {line_type} with data {line_data}"
+            )
+    updates["dependencies"] = [asdict(dep) for dep in deps]
+    updates["dependencies_count"] = len(deps)
+
+    # yarn list doesn't include the root e.g. taskcluster
+    updates["root"] = None
+    updates["direct_dependencies_count"] = None
+
+    # TODO: make sure we're actually resolving a graph
+    updates["graph_stats"] = dict()
+    return updates
+
+
+def parse_npm_audit(parsed_stdout: Dict) -> Dict:
+    # has format:
+    # {
+    #   actions: ...
+    #   advisories: null or {
+    #     <npm adv. id>: {
+    # metadata: null also has an exploitablity score
+    #
+    # } ...
+    #   }
+    #   metadata: null or e.g. {
+    #     "vulnerabilities": {
+    #         "info": 0,
+    #         "low": 0,
+    #         "moderate": 6,
+    #         "high": 0,
+    #         "critical": 0
+    #     },
+    #     "dependencies": 896680,
+    #     "devDependencies": 33885,
+    #     "optionalDependencies": 10215,
+    #     "totalDependencies": 940274
+    #   }
+    # }
+    updates = extract_nested_fields(
+        parsed_stdout,
+        {
+            "dependencies_count": ["metadata", "dependencies"],
+            "dev_dependencies_count": ["metadata", "devDependencies"],
+            "optional_dependencies_count": ["metadata", "optionalDependencies"],
+            "total_dependencies_count": ["metadata", "totalDependencies"],
+            "vulnerabilities": ["metadata", "vulnerabilities"],
+            "advisories": ["advisories"],
+            "error": ["error"],
+        },
+    )
+    updates["advisories"] = (
+        dict() if updates["advisories"] is None else updates["advisories"]
+    )
+    updates["vulnerabilities"] = (
+        dict() if updates["vulnerabilities"] is None else updates["vulnerabilities"]
+    )
+    updates["vulnerabilities_count"] = sum(updates["vulnerabilities"].values())
+    return updates
+
+
+def parse_yarn_audit(parsed_stdout: Sequence[Dict]) -> Optional[Dict]:
+    updates: Dict = dict(advisories=[])
+    for line in parsed_stdout:
+        line_type, line_data = line.get("type", None), line.get("data", dict())
+        if line_type == "auditAdvisory":
+            # TODO: normalize w/ npm advisory output
+            updates["advisories"].append(line_data)
+        elif line_type == "auditSummary":
+            updates.update(
+                extract_nested_fields(
+                    line_data,
+                    {
+                        "dependencies_count": ["dependencies"],
+                        "dev_dependencies_count": ["devDependencies"],
+                        "optional_dependencies_count": ["optionalDependencies"],
+                        "total_dependencies_count": ["totalDependencies"],
+                        "vulnerabilities": ["vulnerabilities"],
+                    },
+                )
+            )
+            updates["vulnerabilities_count"] = sum(updates["vulnerabilities"].values())
+        else:
+            # TODO: populate "error": ["error"], to match npm audit error field?
+            log.warn(
+                f"got unexpected yarn audit line type: {line_type} with data {line_data}"
+            )
+    return updates
+
+
+def parse_npm_task(task_name: str, line: Dict) -> Optional[Dict]:
+    # TODO: reuse cached results for each set of dep files w/ hashes and task name
+    parsed_stdout = parse_stdout_as_json(get_in(line, ["task", "stdout"], None))
+    if parsed_stdout is None:
+        log.warn("got non-JSON stdout for npm")
+        return None
+
+    if task_name == "list_metadata":
+        return parse_npm_list(parsed_stdout)
+    elif task_name == "audit":
+        return parse_npm_audit(parsed_stdout)
+    elif task_name == "install":
+        return None
+    else:
+        raise NotImplementedError()
+
+
+def parse_yarn_task(task_name: str, line: Dict) -> Optional[Dict]:
+    parsed_stdout = parse_stdout_as_jsonlines(get_in(line, ["task", "stdout"], None))
+    if parsed_stdout is None:
+        log.warn("got non-JSON lines stdout for yarn")
+        return None
+
+    if task_name == "list_metadata":
+        return parse_yarn_list(parsed_stdout)
+    elif task_name == "audit":
+        return parse_yarn_audit(parsed_stdout)
+    elif task_name == "install":
+        return None
+    else:
+        raise NotImplementedError()
+
+
 async def run_pipeline(
     source: Generator[Dict[str, Any], None, None], args: argparse.Namespace
 ) -> AsyncGenerator[Dict, None]:
@@ -91,12 +264,6 @@ async def run_pipeline(
         # filter for node list_metadata output to parse and flatten deps
         task_name = get_in(line, ["task", "name"], None)
         if task_name not in args.repo_task:
-            continue
-
-        # TODO: reuse cached results for each set of dep files w/ hashes and task name
-        parsed_stdout = parse_stdout(get_in(line, ["task", "stdout"], None))
-        if parsed_stdout is None:
-            log.debug("got empty stdout")
             continue
 
         result = extract_fields(
@@ -124,87 +291,36 @@ async def run_pipeline(
             ],
         )
 
-        if task_name == "list_metadata":
-            deps = [dep for dep in flatten_deps(parsed_stdout)]
-            result["graph_stats"] = (
-                get_graph_stats(npm_packages_to_networkx_digraph(deps))
-                if deps
-                else dict()
-            )
+        task_command = get_in(line, ["task", "command"], None)
+        if any(
+            task_command == task.command
+            for task in package_managers["npm"].tasks.values()
+        ):
+            updates = parse_npm_task(task_name, line)
+        elif any(
+            task_command == task.command
+            for task in package_managers["yarn"].tasks.values()
+        ):
+            updates = parse_yarn_task(task_name, line)
+        else:
+            continue
 
-            list_results = {"problems": get_in(parsed_stdout, ["problems"], [])}
-            list_results["dependencies"] = [asdict(dep) for dep in deps]
-            list_results["dependencies_count"] = len(deps)
-            list_results["problems_count"] = len(list_results["problems"])
-
-            list_results["root"] = asdict(deps[-1]) if len(deps) else None
-            list_results["direct_dependencies_count"] = (
-                len(deps[-1].dependencies) if len(deps) else None
-            )
-            result.update(list_results)
-            log.info(
-                f"wrote {result['task']['name']} {result['org']}/{result['repo']} {result['task']['relative_path']}"
-                f" {result['ref']['value']} w/"
-                f" {result['dependencies_count']} deps and {result['problems_count']} problems"
-                f" {result['graph_stats']}"
-            )
-        elif task_name == "audit":
-            # has format:
-            # {
-            #   actions: ...
-            #   advisories: null or {
-            #     <npm adv. id>: {
-            # metadata: null also has an exploitablity score
-            #
-            # } ...
-            #   }
-            #   metadata: null or e.g. {
-            #     "vulnerabilities": {
-            #         "info": 0,
-            #         "low": 0,
-            #         "moderate": 6,
-            #         "high": 0,
-            #         "critical": 0
-            #     },
-            #     "dependencies": 896680,
-            #     "devDependencies": 33885,
-            #     "optionalDependencies": 10215,
-            #     "totalDependencies": 940274
-            #   }
-            # }
-            result.update(
-                extract_nested_fields(
-                    parsed_stdout,
-                    {
-                        "dependencies_count": ["metadata", "dependencies"],
-                        "dev_dependencies_count": ["metadata", "devDependencies"],
-                        "optional_dependencies_count": [
-                            "metadata",
-                            "optionalDependencies",
-                        ],
-                        "total_dependencies_count": ["metadata", "totalDependencies"],
-                        "vulnerabilities": ["metadata", "vulnerabilities"],
-                        "advisories": ["advisories"],
-                        "error": ["error"],
-                    },
+        if updates:
+            if task_name == "list_metadata":
+                log.info(
+                    f"wrote {result['task']['name']} {result['org']}/{result['repo']} {result['task']['relative_path']}"
+                    f" {result['ref']['value']} w/"
+                    f" {updates['dependencies_count']} deps and {updates.get('problems_count', 0)} problems"
+                    # f" {updates['graph_stats']}"
                 )
-            )
-            result["advisories"] = (
-                dict() if result["advisories"] is None else result["advisories"]
-            )
-            result["vulnerabilities"] = (
-                dict()
-                if result["vulnerabilities"] is None
-                else result["vulnerabilities"]
-            )
-            result["vulnerabilities_count"] = sum(result["vulnerabilities"].values())
-
-            log.info(
-                f"wrote {result['task']['name']} {result['org']}/{result['repo']} {result['task']['relative_path']}"
-                f" {result['ref']['value']} w/"
-                f" {result['vulnerabilities_count']} vulns"
-            )
-        yield result
+            elif task_name == "audit":
+                log.info(
+                    f"wrote {result['task']['name']} {result['org']}/{result['repo']} {result['task']['relative_path']}"
+                    f" {result['ref']['value']} w/"
+                    f" {updates['vulnerabilities_count']} vulns"
+                )
+            result.update(updates)
+            yield result
 
 
 FIELDS: AbstractSet = set()

--- a/fpr/run_pipeline.py
+++ b/fpr/run_pipeline.py
@@ -45,6 +45,12 @@ def parse_args():
         default=False,
         help="don't log anything to the console",
     )
+    parser.add_argument(
+        "--save-to-tmpfile",
+        action="store_true",
+        default=False,
+        help="Save unserialized and serizalized results to temp files. Defaults to False.",
+    )
 
     subparsers = parser.add_subparsers(help="available pipelines", dest="pipeline_name")
     for pipeline in pipelines:
@@ -86,16 +92,19 @@ def main():
 
     async def main():
         async for row in pipeline.runner(pipeline.reader(args.infile), args):
-            save_to_tmpfile(
-                f"{args.pipeline_name}_unserialized_", file_ext=".pickle", item=row
-            )
+            if args.save_to_tmpfile:
+                save_to_tmpfile(
+                    f"{args.pipeline_name}_unserialized_", file_ext=".pickle", item=row
+                )
+
             try:
                 serialized = pipeline.serializer(args, row)
-                save_to_tmpfile(
-                    f"{args.pipeline_name}_serialized_",
-                    file_ext=".json",
-                    item=serialized,
-                )
+                if args.save_to_tmpfile:
+                    save_to_tmpfile(
+                        f"{args.pipeline_name}_serialized_",
+                        file_ext=".json",
+                        item=serialized,
+                    )
                 writer = getattr(pipeline, "writer")
                 writer(args.outfile, serialized)
                 if args.append_outfile:

--- a/fpr/run_pipeline.py
+++ b/fpr/run_pipeline.py
@@ -79,16 +79,13 @@ def main():
     asyncio.set_event_loop(loop)
 
     pipeline = next(p for p in pipelines if p.name == args.pipeline_name)
+    log_line = (
+        f"running pipeline {args.pipeline_name} on {args.infile.name} writing to "
+        f"{args.outfile.name}"
+    )
     if args.append_outfile:
-        log.info(
-            f"running pipeline {args.pipeline_name} on {args.infile.name} writing to "
-            f"{args.outfile.name} and appending to {args.append_outfile.name}"
-        )
-    else:
-        log.info(
-            f"running pipeline {args.pipeline_name} on {args.infile.name} writing to "
-            f"{args.outfile.name}"
-        )
+        log_line += f"and appending to {args.append_outfile.name}"
+    log.info(log_line)
 
     async def main():
         async for row in pipeline.runner(pipeline.reader(args.infile), args):


### PR DESCRIPTION
Changes:

* define docker image and image name models for #23 and use them for node meta pipeline
* add images to languages
* add newlines to task stdout (JSON line support for yarn)
* add yarn support to nodejs meta and postprocess pipelines
* add option and don't save tmpfiles for unserialized and serialized results